### PR TITLE
Fix repositories order

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -24,10 +24,10 @@ ext {
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
**Starting in Meteor 1.7.**

Due to recent changes, Android is no longer supporting downloading support libraries through the SDK Manager. The support libraries are now available through Google's Maven repository.

This leads to not be able to install some plugins which are up to date with this rule.

For some reasons, just inverting the repository search order will fix the problem. As seen in https://github.com/meteor/meteor/issues/10308

This PR does the following:

- inverse the repositories order